### PR TITLE
add a folder to maintain BQ QA queries

### DIFF
--- a/BQ_metadata_checks/find_clashing_UIDs.sql
+++ b/BQ_metadata_checks/find_clashing_UIDs.sql
@@ -5,35 +5,62 @@ WITH
     WITH
       distinct_studies AS (
       SELECT
-        DISTINCT(StudyInstanceUID) AS UID
+        StudyInstanceUID AS UID,
+        "study" AS where_used,
+        STRING_AGG(DISTINCT(collection_id)) AS collections,
+        STRING_AGG(DISTINCT(PatientID)) AS patientIDs
       FROM
-        `idc-dev-etl.idc_tcia_views_dev.dicom_all`),
+        `idc-dev-etl.idc_tcia_views_dev.dicom_all`
+      GROUP BY
+        StudyInstanceUID),
       distinct_series AS (
       SELECT
-        DISTINCT(SeriesInstanceUID) AS UID
+        SeriesInstanceUID AS UID,
+        "series" AS where_used,
+        STRING_AGG(DISTINCT(collection_id)) AS collections,
+        STRING_AGG(DISTINCT(PatientID)) AS patientIDs
       FROM
-        `idc-dev-etl.idc_tcia_views_dev.dicom_all`),
+        `idc-dev-etl.idc_tcia_views_dev.dicom_all`
+      GROUP BY
+        SeriesInstanceUID),
       distinct_instances AS (
       SELECT
-        DISTINCT(SOPInstanceUID) AS UID
+        SOPInstanceUID AS UID,
+        "instance" AS where_used,
+        STRING_AGG(DISTINCT(collection_id)) AS collections,
+        STRING_AGG(DISTINCT(PatientID)) AS patientIDs
       FROM
-        `idc-dev-etl.idc_tcia_views_dev.dicom_all`)
+        `idc-dev-etl.idc_tcia_views_dev.dicom_all`
+      GROUP BY
+        SOPInstanceUID)
     SELECT
-      UID
+      UID,
+      where_used,
+      collections,
+      patientIDs
     FROM
       distinct_studies
     UNION ALL
     SELECT
-      UID
+      UID,
+      where_used,
+      collections,
+      patientIDs
     FROM
       distinct_series
     UNION ALL
     SELECT
-      UID
+      UID,
+      where_used,
+      collections,
+      patientIDs
     FROM
       distinct_instances)
   SELECT
     COUNT(UID) AS uid_counts,
+    STRING_AGG(DISTINCT(where_used)) AS where_used,
+    STRING_AGG(DISTINCT(collections)) AS collections,
+    STRING_AGG(DISTINCT(patientIDs)) AS patientIDs,
     uid
   FROM
     all_uids
@@ -42,9 +69,14 @@ WITH
   ORDER BY
     uid_counts DESC )
 SELECT
-  uid_counts,
-  uid
+  UID,
+  where_used,
+  collections,
+  patientIDs,
+  uid_counts
 FROM
   more_than_once_uids
 WHERE
   uid_counts > 1
+ORDER BY
+  collections

--- a/BQ_metadata_checks/find_clashing_UIDs.sql
+++ b/BQ_metadata_checks/find_clashing_UIDs.sql
@@ -1,0 +1,38 @@
+# count all distinct UIDs used for Study/Series/SOPInstanceUID
+# to confirm each one is unique at its own level of hierarchy
+WITH
+  all_uids AS (
+  WITH
+    distinct_studies AS (
+    SELECT
+      DISTINCT(StudyInstanceUID) AS UID
+    FROM
+      `idc-dev-etl.idc_tcia_views_dev.dicom_all`),
+    distinct_series AS (
+    SELECT
+      DISTINCT(SeriesInstanceUID) AS UID
+    FROM
+      `idc-dev-etl.idc_tcia_views_dev.dicom_all`),
+    distinct_instances AS (
+    SELECT
+      DISTINCT(SOPInstanceUID) AS UID
+    FROM
+      `idc-dev-etl.idc_tcia_views_dev.dicom_all`)
+  SELECT
+    UID
+  FROM
+    distinct_studies
+  UNION ALL
+  SELECT
+    UID
+  FROM
+    distinct_series)
+SELECT
+  COUNT(UID) AS uid_counts,
+  uid
+FROM
+  all_uids
+GROUP BY
+  uid
+ORDER BY
+  uid_counts DESC

--- a/BQ_metadata_checks/find_clashing_UIDs.sql
+++ b/BQ_metadata_checks/find_clashing_UIDs.sql
@@ -1,38 +1,50 @@
-# count all distinct UIDs used for Study/Series/SOPInstanceUID
-# to confirm each one is unique at its own level of hierarchy
 WITH
-  all_uids AS (
+  more_than_once_uids AS (
   WITH
-    distinct_studies AS (
+    all_uids AS (
+    WITH
+      distinct_studies AS (
+      SELECT
+        DISTINCT(StudyInstanceUID) AS UID
+      FROM
+        `idc-dev-etl.idc_tcia_views_dev.dicom_all`),
+      distinct_series AS (
+      SELECT
+        DISTINCT(SeriesInstanceUID) AS UID
+      FROM
+        `idc-dev-etl.idc_tcia_views_dev.dicom_all`),
+      distinct_instances AS (
+      SELECT
+        DISTINCT(SOPInstanceUID) AS UID
+      FROM
+        `idc-dev-etl.idc_tcia_views_dev.dicom_all`)
     SELECT
-      DISTINCT(StudyInstanceUID) AS UID
+      UID
     FROM
-      `idc-dev-etl.idc_tcia_views_dev.dicom_all`),
-    distinct_series AS (
+      distinct_studies
+    UNION ALL
     SELECT
-      DISTINCT(SeriesInstanceUID) AS UID
+      UID
     FROM
-      `idc-dev-etl.idc_tcia_views_dev.dicom_all`),
-    distinct_instances AS (
+      distinct_series
+    UNION ALL
     SELECT
-      DISTINCT(SOPInstanceUID) AS UID
+      UID
     FROM
-      `idc-dev-etl.idc_tcia_views_dev.dicom_all`)
+      distinct_instances)
   SELECT
-    UID
+    COUNT(UID) AS uid_counts,
+    uid
   FROM
-    distinct_studies
-  UNION ALL
-  SELECT
-    UID
-  FROM
-    distinct_series)
+    all_uids
+  GROUP BY
+    uid
+  ORDER BY
+    uid_counts DESC )
 SELECT
-  COUNT(UID) AS uid_counts,
+  uid_counts,
   uid
 FROM
-  all_uids
-GROUP BY
-  uid
-ORDER BY
-  uid_counts DESC
+  more_than_once_uids
+WHERE
+  uid_counts > 1


### PR DESCRIPTION
Added query to count unique UIDs used for Study/Series/SOPInstanceUID.

@bcli4d let's keep queries of this sort in this folder, and then maybe they can be executed automatically as part of the ETL process, to reduce the risk of surprises like the one we had yesterday?